### PR TITLE
Fixed the regex to also match alpha values starting with zero or a decimal point: rgba(0, 0, 0, .5) or rgba(0, 0, 0, 0.5)

### DIFF
--- a/src/colorProvider.js
+++ b/src/colorProvider.js
@@ -15,7 +15,7 @@ import {
   const colorMatchShort =
     /#([0-9a-fA-F]{3})([0-9a-fA-F]{1})?/;
   // rgba(255, 0, 153, 1);
-  const rgbaMatch = /rgba?\(\s*\d+\s*,\s*\d+\s*,\s*\d+\s*(,\s*\d+\s*)?\)/;
+  const rgbaMatch = /rgba?\(\s*\d+\s*,\s*\d+\s*,\s*\d+\s*(,\s*(0\.|\.)?\d+\s*)?\)/;
   // hsl(60, 100%, 50%)
   const hslMatch = /hsl\(\s*(\d+)\s*,\s*([\d.]+)%\s*,\s*([\d.]+)%\s*\)/;
   // only match if followed by , or :


### PR DESCRIPTION
In my case extension works as expected only if I set `backgroundColor` to `rgba(0, 255, 0, 1)`:
![Screenshot 2025-06-17 at 14 28 08](https://github.com/user-attachments/assets/b70cf7e5-b787-437f-8e51-8a2ffde45166)

Changing the alfa-value to zero  `rgba(0, 255, 0, 0)` removes the color preview beside the hex:
![Screenshot 2025-06-17 at 14 29 14](https://github.com/user-attachments/assets/e2a23285-8dcf-4fb3-ab70-bc482abc7d6c)

If I set alfa-value to float with leading zero  `rgba(0, 255, 0, 0.5)` the extension don't recognise this string as a color value at all:
![Screenshot 2025-06-17 at 14 29 45](https://github.com/user-attachments/assets/53f8606b-1764-4e38-abd4-8413ac07cec7)
and the same behaviour if i set alfa-value to float w/o leading zero `rgba(0, 255, 0, .5)`:
![Screenshot 2025-06-17 at 14 30 10](https://github.com/user-attachments/assets/e4bbd33a-44a9-4638-8d53-888792cc374a)

I checked my solution on regex101.com (links lead to examples from images):

Old expression on [regex101.com](https://regex101.com/r/T8DwCk/1):
<img width="682" alt="Screenshot 2025-06-17 at 14 33 13" src="https://github.com/user-attachments/assets/47365e4c-3a3f-4672-b023-ee2ed879a4de" />

Fixed expression on [regex101.com](https://regex101.com/r/T8DwCk/2):
<img width="679" alt="Screenshot 2025-06-17 at 14 32 28" src="https://github.com/user-attachments/assets/352e05f8-cbad-4cde-8a75-9c12dcbb826e" />

